### PR TITLE
Modify the link to the user page in jobs details

### DIFF
--- a/clockwork_web/templates/single_job.html
+++ b/clockwork_web/templates/single_job.html
@@ -49,7 +49,7 @@
                                 <td><a href="/nodes/single_node/{{v}}"> {{v}} </a></td>
                             {% elif k == "username" %}
                                 <td>
-                                  <a href="/users/one?username={{D_single_job_cw['mila_username']}}">
+                                  <a href="/users/one?username={{D_single_job_cw['mila_email_username']}}">
                                     {{v}}
                                   </a>
                                 </td>


### PR DESCRIPTION
# Description
This Pull Request contains a minor correction, for the following issue:
In the page detailing a job, there is a problem in the link to the job owner's page: the `username` argument of the target URL has the format `studentXX` instead of `studentXX@mila.quebec`.