### PR TITLE
Fix the dropdown menu to select the number of elements to display per page

### DIFF
--- a/clockwork_web/static/js/settings.js
+++ b/clockwork_web/static/js/settings.js
@@ -1,0 +1,45 @@
+/*
+    This page gathers some functions used by the template settings.html.
+    It should only be included in this template, as it uses some variables
+    and HTML elements which may not exist in other templates.
+*/
+
+/*
+    Generate the content of the dropdown menu for chosing what the number
+    of elements to display per listing page should be for the current user.
+
+    Parameters:
+        - current_nbr_items_per_page    The number of items to display per
+                                        listing page which is currently stored
+                                        in the user settings
+*/
+function fill_nbr_items_per_page_dropdown_menu(current_nbr_items_per_page) {
+    // Initialise the list of options for the values of nbr_items_per_page
+    // proposed to the user
+    let nbr_items_per_page_options = [25, 50, 100];
+
+    // Add the current_nbr_items_per_page to this list if it is not contained
+    // in it yet
+    if (!nbr_items_per_page_options.includes(current_nbr_items_per_page)) {
+        nbr_items_per_page_options.push(current_nbr_items_per_page);
+    }
+
+    // Sort the list
+    nbr_items_per_page_options.sort(function(a,b) {
+        return a-b;
+    });
+
+    // Fill the dropdown menu with the content of the list
+    let nbr_items_per_page_menu = document.getElementById("nbr_items_per_page_selection"); // Retrieve the dropdown menu
+    nbr_items_per_page_menu.innerHTML = ""; // Clear its content
+    for (let i=0; i<nbr_items_per_page_options.length; i++) {
+        let option = document.createElement("option");
+        option.value = nbr_items_per_page_options[i]; // Value of the option
+        option.text = nbr_items_per_page_options[i]; // Text that appears for this option in the dropdown menu
+        // Preselect the current option
+        if (nbr_items_per_page_options[i] == current_nbr_items_per_page) {
+            option.selected = true;
+        }
+        nbr_items_per_page_menu.appendChild(option);
+    }
+}

--- a/clockwork_web/templates/settings.html
+++ b/clockwork_web/templates/settings.html
@@ -7,6 +7,7 @@
 	</style>
 	<!-- <link rel="stylesheet" href="{{ url_for('static', filename='css/clockwise.css') }}"> -->
 	<script type="text/javascript" src="{{ url_for('static', filename='js/user.js') }}"></script>
+	<script type="text/javascript" src="{{ url_for('static', filename='js/settings.js') }}"></script>
 	<script>
 		{% autoescape false %}
 		{{extra_js}}
@@ -62,10 +63,7 @@
 					<dt class="col-4">{{ gettext("Number of items displayed per page") }}</dt>
 		  			<dd class="col-8">
 						<select class="form-select" name="nbr_items_per_page_selection" id="nbr_items_per_page_selection" onchange="select_nbr_items_per_page(this)">
-							<option value='{{web_settings["nbr_items_per_page"]}}'>{{web_settings["nbr_items_per_page"]}}</option>
-							<option value="25">25</option>
-							<option value="50">50</option>
-							<option value="100">100</option>
+							<!-- This is filled through the javascript -->
 						</select>
 					</dd>
 		 
@@ -86,5 +84,10 @@
 		  </div>
 		</div>
 	</div>
+	<script>
+		// Fill the dropdown menu allowing to chose the preferred number of elements to
+		// display in a listing page
+		fill_nbr_items_per_page_dropdown_menu({{web_settings["nbr_items_per_page"]}});
+	</script>
 
 {% endblock %}


### PR DESCRIPTION
The dropdown menu to select the user's preferred number of elements to display per page when listing entities presents the two following "issues":
* If the current preferred number of elements to display is up to 25, the list of the dropdown menu is not sorted, as the current element appears as the first element.
* If the current preferred number of elements to display is in the default values (25, 50 or 100), it appears twice in the list.