### PR TITLE
Update the href of the button "See all jobs" on the dashboard

### DIFF
--- a/clockwork_web/static/locales/fr/LC_MESSAGES/messages.po
+++ b/clockwork_web/static/locales/fr/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-09-07 13:56-0400\n"
+"POT-Creation-Date: 2022-09-07 15:57-0400\n"
 "PO-Revision-Date: 2022-07-14 15:23-0400\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: fr\n"
@@ -141,6 +141,38 @@ msgstr "date de début"
 #: clockwork_web/templates/jobs.html:42
 msgid "end time"
 msgstr "date de fin"
+
+#: clockwork_web/templates/jobs_interactive.html:104
+msgid "Welcome back"
+msgstr "Bienvenue"
+
+#: clockwork_web/templates/jobs_interactive.html:116
+msgid "Running jobs"
+msgstr "Jobs roulantes"
+
+#: clockwork_web/templates/jobs_interactive.html:125
+msgid "Completed jobs"
+msgstr "Jobs complétées"
+
+#: clockwork_web/templates/jobs_interactive.html:134
+msgid "Pending jobs"
+msgstr "Jobs en attente"
+
+#: clockwork_web/templates/jobs_interactive.html:143
+msgid "Stalled jobs"
+msgstr "Jobs bloquées"
+
+#: clockwork_web/templates/jobs_interactive.html:148
+msgid "See all jobs"
+msgstr "Voir toutes les jobs"
+
+#: clockwork_web/templates/jobs_interactive.html:160
+msgid "YOUR JOBS"
+msgstr "VOS JOBS"
+
+#: clockwork_web/templates/jobs_interactive.html:160
+msgid "This list will auto-refresh!"
+msgstr "Cette liste s'auto-rafraîchira !"
 
 #: clockwork_web/templates/nodes.html:24
 msgid "nodes"

--- a/clockwork_web/templates/jobs_interactive.html
+++ b/clockwork_web/templates/jobs_interactive.html
@@ -101,7 +101,7 @@
                 <div class="col-12">
                     <div class="title float-start">
                         <i class="fa-solid fa-user"></i>
-                        <h1>Welcome back <script>document.writeln(readableusername);</script>!<span class="message"><i class="fa-solid fa-list-check"></i>You currently have: </span></h1>
+                        <h1>{{ gettext("Welcome back") }} <script>document.writeln(readableusername);</script>!<span class="message"><i class="fa-solid fa-list-check"></i>You currently have: </span></h1>
                     </div>
                     <!-- <a class="btn" onclick="server_refresh()">refresh</a> -->
                 </div>
@@ -113,7 +113,7 @@
                         <i class="fa-solid fa-timer"></i>
                         <span id="dashboard_running" class="num"></span>
                         <i class="fa-solid fa-arrows-rotate"></i>
-                        <p>Running jobs</p>
+                        <p>{{ gettext("Running jobs") }}</p>
                     </div>
                 </div>
 
@@ -122,7 +122,7 @@
                         <i class="fa-solid fa-badge-check"></i>
                         <span id="dashboard_completed" class="num"></span>
                         <i class="fa-solid fa-arrows-rotate"></i>
-                        <p>Completed jobs</p>
+                        <p>{{ gettext("Completed jobs") }}</p>
                     </div>
                 </div>
 
@@ -131,7 +131,7 @@
                         <i class="fa-solid fa-circle-pause"></i>
                         <span id="dashboard_pending" class="num"></span>
                         <i class="fa-solid fa-arrows-rotate"></i>
-                        <p>Pending jobs</p>
+                        <p>{{ gettext("Pending jobs") }}</p>
                     </div>
                 </div>
 
@@ -140,12 +140,12 @@
                         <i class="fa-solid fa-triangle-exclamation"></i>
                         <span id="dashboard_stalled" class="num"></span>
                         <i class="fa-solid fa-arrows-rotate"></i>
-                        <p>Stalled jobs</p>
+                        <p>{{ gettext("Stalled jobs") }}</p>
                     </div>
                 </div>
 
                 <div class="col-md-3 offset-md-9 col-xs-12">
-                    <a class="btn btn-red mb-3">See all jobs</a>
+                    <a class="btn btn-red mb-3" href="/jobs/search">{{ gettext("See all jobs") }}</a>
                 </div>
             </div>
 
@@ -157,7 +157,7 @@
             <div class="col-12">
                 <div class="title float-start">
                     <i class="fa-solid fa-list-check"></i>
-                    <h1>YOUR JOBS<span class="message"><i id="spinner" class="fa-solid fa-arrows-rotate"></i>This list will auto-refresh! </span></h1>
+                    <h1>{{ gettext("YOUR JOBS") }}<span class="message"><i id="spinner" class="fa-solid fa-arrows-rotate"></i>{{ gettext("This list will auto-refresh!") }}</span></h1>
                 </div>
                 <!-- <a class="btn" onclick="server_refresh()">refresh</a> -->
             </div>


### PR DESCRIPTION
The button "See all jobs" on the page `/jobs/interactive` does not redirect to `/jobs/search`.