### PR TITLE
Hide the Jobs Search form for a unauthenticated user

### DIFF
--- a/clockwork_web/templates/base.html
+++ b/clockwork_web/templates/base.html
@@ -126,7 +126,7 @@
 		</div>
 
 		{% block form %}
-		{% if request.path != '/jobs/interactive' %}
+		{% if request.path != '/jobs/interactive' and current_user.is_authenticated %}
 			<div id="formBlock">
 				<div class="search_button formCollapse collapse" id="mainCollapse">
 					<div class="container">


### PR DESCRIPTION
The "Jobs search" form appears when a user is not authenticated.

![dashboard_unauthentified](https://user-images.githubusercontent.com/85968577/189157720-3720a7c5-1934-4ec6-819a-7ed65cc7dd1b.png)
