### PR TITLE
Fix the counting of jobs or nodes when displaying a list

### DIFF
--- a/clockwork_web/browser_routes/jobs.py
+++ b/clockwork_web/browser_routes/jobs.py
@@ -143,7 +143,7 @@ def route_list():
 
     if want_json:
         # If requested, return the list as JSON
-        return jsonify(LD_jobs)
+        return jsonify({"nbr_total_jobs": nbr_total_jobs, "jobs": LD_jobs})
     else:
         # Otherwise, display the HTML page
         return render_template_with_user_settings(
@@ -238,10 +238,11 @@ def route_search():
     # Retrieve the jobs and display them
     ###
     # Retrieve the jobs, by applying the filters and the pagination
-    (LD_jobs, _) = get_jobs(
+    (LD_jobs, nbr_total_jobs) = get_jobs(
         filter,
         nbr_skipped_items=nbr_skipped_items,
         nbr_items_to_display=nbr_items_to_display,
+        want_count=True,  # We want the result as a tuple (jobs_list, jobs_count)
     )
 
     # TODO : You might want to stop doing the `infer_best_guess_for_username`
@@ -257,6 +258,7 @@ def route_search():
         LD_jobs=LD_jobs,
         mila_email_username=current_user.mila_email_username,
         page_num=pagination_page_num,
+        nbr_total_jobs=nbr_total_jobs,
         previous_request_args=previous_request_args,
     )
 

--- a/clockwork_web/static/js/dashboard.js
+++ b/clockwork_web/static/js/dashboard.js
@@ -155,7 +155,7 @@ function refresh_display(display_filter) {
         Clear and populate the jobs table with the latest response content,
         filtered by the "display filters" given as parameters.
     */
-    latest_filtered_response_contents = apply_filter(latest_response_contents, display_filter);
+    latest_filtered_response_contents = apply_filter(latest_response_contents["jobs"], display_filter);
     vacate_table(); // idempotent if not table is present
     populate_table(latest_filtered_response_contents);
     //kaweb - for some reason, the sortable init only works on reload/first load, not after changing filters

--- a/clockwork_web/static/js/jobs.js
+++ b/clockwork_web/static/js/jobs.js
@@ -155,7 +155,7 @@ function refresh_display(display_filter) {
         Clear and populate the jobs table with the latest response content,
         filtered by the "display filters" given as parameters.
     */
-    latest_filtered_response_contents = apply_filter(latest_response_contents, display_filter);
+    latest_filtered_response_contents = apply_filter(latest_response_contents["jobs"], display_filter);
     vacate_table(); // idempotent if not table is present
     populate_table(latest_filtered_response_contents);
     //kaweb - for some reason, the sortable init only works on reload/first load, not after changing filters


### PR DESCRIPTION
The purpose of this Pull Request is to:
* return `nbr_total_jobs` when calling `/jobs/search`
* return `nbr_total_jobs` when `/jobs/list` is called with the parameter `want_json=True` (NB: with `want_json=False`, this number is already returned.