### PR TITLE
Represent all job states in fake data

### DIFF
--- a/clockwork_tools_test/conftest.py
+++ b/clockwork_tools_test/conftest.py
@@ -69,7 +69,9 @@ def db_with_fake_data():
     assert "MONGODB_DATABASE_NAME" in os.environ
 
     db = MongoClient(os.environ["MONGODB_CONNECTION_STRING"])
-    cleanup_function = populate_fake_data(db[os.environ["MONGODB_DATABASE_NAME"]])
+    cleanup_function = populate_fake_data(
+        db[os.environ["MONGODB_DATABASE_NAME"]], mutate=True
+    )
     yield db  # This would be `yield None` instead to make our intentions more explicit.
     cleanup_function()
 


### PR DESCRIPTION
Simple rehaul of fake_data so that we have jobs with all possible SLURM states. This required fixing a few states. The test for the jobs/search route has also been fixed to verify not just that the expected jobs are present, but also that the unexpected jobs are not present.

Upon doing this, it appeared some possible states were not represented as icons in the dashboard. This is also fixed.

I removed the minified files scripts.min.js and dashboard.min.js, because they are not used and there doesn't seem to be a mechanism to ensure they are in sync with the development files. I also added "use strict"; to dashboard.js and added the missing variable declarations.
