### PR TITLE
Add aggregated_job_state to query

### DIFF
--- a/clockwork_web_test/test_browser_jobs.py
+++ b/clockwork_web_test/test_browser_jobs.py
@@ -438,11 +438,11 @@ def test_route_search(
 
     # Intersection between the requested clusters (if specified)
     # and the clusters available for the current user.
+    if not cluster_names:
+        cluster_names = get_available_clusters_from_db(current_user_id)
     requested_clusters = set(cluster_names).intersection(
         set(get_available_clusters_from_db(current_user_id))
     )
-    if not requested_clusters:
-        requested_clusters = get_available_clusters_from_db(current_user_id)
 
     # Sort the jobs contained in the fake data by submit time, then by job id
     sorted_all_jobs = sorted(


### PR DESCRIPTION
This is based on #118

* There are now two distinct search parameters, aggregated_job_state and job_state. The first is fuzzy, the second is exact.
* The code that queries jobs based on the request parameters has been abstracted in search_helper.py and is used for the browser and rest routes.
* Specific tests for the feature are still missing, although all existing tests pass.
