### PR TITLE
Fix pagination display and 'not pagination' option

### DIFF
--- a/clockwork_web/core/search_helper.py
+++ b/clockwork_web/core/search_helper.py
@@ -62,7 +62,7 @@ def parse_search_request(user, args, force_pagination=True):
     #########################
 
     if (
-        force_pagination
+        not force_pagination
         and not query.pagination_page_num
         and not query.pagination_nbr_items_per_page
     ):
@@ -93,7 +93,8 @@ def search_request(user, args, force_pagination=True):
         job_states=query.job_state,
         nbr_skipped_items=query.nbr_skipped_items,
         nbr_items_to_display=query.nbr_items_to_display,
-        want_count=force_pagination,  # The count is needed if there is pagination
+        want_count=force_pagination
+        or query.want_count,  # The count is needed if there is pagination or if it is requested
         sort_by=query.sort_by,
         sort_asc=query.sort_asc,
     )

--- a/clockwork_web/templates/jobs_search.html
+++ b/clockwork_web/templates/jobs_search.html
@@ -255,7 +255,8 @@
                 {% endif %}
 
                 {% if nbr_items_per_page > 0 %}
-                    {% set total_pages = total_items // nbr_items_per_page | int %}
+                    {# Get the number of pages by rounding up the number of items divided by the number of items per pages #}
+                    {% set total_pages = ((total_items / nbr_items_per_page) | round(0, 'ceil') | int) %}
                 {% else %}
                     {% set total_pages = 1 %}
                 {% endif %}
@@ -293,7 +294,6 @@
                             {% if (page_num < total_pages - 3): %}
                                 <li><span class="ellipses">...</span></li>
                             {% endif %}
-
                             {% if page_num == total_pages %}
                                 <li class="page-item last"><span><i class="fa-solid fa-caret-right"></i></span></li>
                             {% else %}


### PR DESCRIPTION
In `/core/search_helper.py`: allows a unpaginated result

In`templates/jobs_search.html`: correctly diplays the number of pages (the number was rounded down and not up)