### PR TITLE
CW-171 - Allow to test clockwork frontend (server web page content and behavior) using Playwright.

### DIFF
--- a/.github/workflows/ci_frontend.yml
+++ b/.github/workflows/ci_frontend.yml
@@ -1,0 +1,20 @@
+name: Clockwork frontend tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  clockwork-frontend-tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Launch docker
+      run: docker build -t clockwork_dev -f clockwork_dev.Dockerfile .
+    - name: Launch frontend tests
+      run: |
+        . ./env.sh
+        docker-compose run clockwork_dev scripts/launch_frontend_tests_in_clockwork_dev.sh

--- a/clockwork_dev.Dockerfile
+++ b/clockwork_dev.Dockerfile
@@ -1,6 +1,14 @@
 FROM python:3.9-slim-buster
 
 RUN mkdir /clockwork
+# Create folder required by Playwright to install browsers,
+# and set permissions so that Playwright can install browsers in these folders.
+RUN mkdir /.cache
+RUN chmod -R 777 /.cache
+RUN chmod -R 777 /clockwork
+
+# Add a variable available only inside container.
+ENV WE_ARE_IN_DOCKER=1
 
 ENV CLOCKWORK_ROOT=/clockwork
 ENV PYTHONPATH=${PYTHONPATH}:${CLOCKWORK_ROOT}:${CLOCKWORK_ROOT}/clockwork_tools
@@ -14,6 +22,10 @@ ENV MONGODB_DATABASE_NAME="clockwork"
 # to have gcc to build `dulwich` used by poetry
 RUN apt update && apt install -y build-essential
 
+# Install OS packages required for Playwright browsers
+# https://github.com/microsoft/playwright-python/issues/498#issuecomment-856349356
+RUN apt install -y gstreamer1.0-libav libnss3-tools libatk-bridge2.0-0 libcups2-dev libxkbcommon-x11-0 libxcomposite-dev libxrandr2 libgbm-dev libgtk-3-0
+
 RUN pip install --upgrade pip poetry
 
 COPY clockwork_web/requirements.txt /requirements_web.txt
@@ -21,6 +33,11 @@ RUN pip install -r /requirements_web.txt && rm -rf /root/.cache
 
 COPY clockwork_web_test/requirements.txt /requirements_web_test.txt
 RUN pip install -r /requirements_web_test.txt && rm -rf /root/.cache
+
+# Install Python requirements for clockwork frontend/javascript tests.
+# This include package `pytest-playwright`.
+COPY clockwork_frontend_test/requirements.txt /requirements_frontend_test.txt
+RUN pip install -r /requirements_frontend_test.txt && rm -rf /root/.cache
 
 COPY clockwork_tools/poetry.lock /poetry.lock
 COPY clockwork_tools/pyproject.toml /pyproject.toml

--- a/clockwork_frontend_test/requirements.txt
+++ b/clockwork_frontend_test/requirements.txt
@@ -1,0 +1,1 @@
+pytest-playwright==0.3.3

--- a/clockwork_frontend_test/test_frontend.py
+++ b/clockwork_frontend_test/test_frontend.py
@@ -1,0 +1,36 @@
+import os
+import pytest
+from playwright.sync_api import Page, expect
+
+
+# Generate base url depending on whether we are inside docker container or not.
+IN_DOCKER = os.environ.get("WE_ARE_IN_DOCKER", False)
+BASE_URL = f"http://127.0.0.1:{5000 if IN_DOCKER else 15000}"
+
+
+def test_login(page: Page):
+    """Test login with student00 and verify page contains expected welcome message."""
+    page.goto(f"{BASE_URL}/login/testing?user_id=student00@mila.quebec")
+    header_title = page.locator("#formBlock > .container .title.float-start h1")
+    expect(header_title).to_contain_text("Welcome back student00 !")
+
+
+def test_bad_assertion_on_header_title(page: Page):
+    """Verify that test fails if we look for an unexpected welcome message."""
+    page.goto(f"{BASE_URL}/login/testing?user_id=student00@mila.quebec")
+    header_title = page.locator("#formBlock > .container .title.float-start h1")
+    with pytest.raises(AssertionError):
+        expect(header_title).to_contain_text("Welcome back student01 !")
+
+
+def test_see_all_jobs(page: Page):
+    """Test click on `see all jobs` button."""
+    page.goto(f"{BASE_URL}/login/testing?user_id=student00@mila.quebec")
+    expect(page.get_by_text("search")).to_have_count(0)
+
+    button = page.locator("#formBlock > .container .row.dashboard_job .btn.btn-red")
+    expect(button).to_have_count(1)
+    expect(button).to_contain_text("See all jobs")
+    button.click()
+    expect(page).to_have_url(f"{BASE_URL}/jobs/search")
+    assert page.get_by_text("search").count()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,7 @@ services:
     ports:
       - ${EXTERNAL_FLASK_RUN_PORT}:${FLASK_RUN_PORT}
     volumes:
+      - ./clockwork_frontend_test:/clockwork/clockwork_frontend_test
       - ./clockwork_tools:/clockwork/clockwork_tools
       - ./clockwork_tools_test:/clockwork/clockwork_tools_test
       - ./clockwork_web:/clockwork/clockwork_web

--- a/scripts/launch_frontend_tests_in_clockwork_dev.sh
+++ b/scripts/launch_frontend_tests_in_clockwork_dev.sh
@@ -1,0 +1,21 @@
+set -eu
+
+echo Install playwright browser Chromium
+playwright install chromium
+
+echo Store fake data
+python3 scripts/store_fake_data_in_db.py
+
+echo Launch clockwork web server in background
+python3 -m flask run --host="0.0.0.0" &
+
+echo Wait 5 seconds to let server fully start
+sleep 5
+
+echo Check that server is onlinw
+python -c "import urllib.request; print(urllib.request.urlopen('http://127.0.0.1:5000/').getcode())"
+
+echo Run tests
+pytest -vv clockwork_frontend_test
+
+echo Frontend tests done.


### PR DESCRIPTION
Hi @soline-b ! This is my PR to allow frontend unit tests.

I use Playwright: https://playwright.dev/python/

Current code allows to test content and behavior for a web page fully loaded. As examples, I added 3 simple tests.

NB: JIRA ticket also talked about testing an isolated piece of Javascript code without having to load an entire page. For now, I don't yet know how to do that, especially because current Javascript code depends on backend Flask variables, that are available only if server is fully loaded.