### PR TITLE
CW-274 - [frontend/job search] add buttons "first page" and "last page" to pagination

### DIFF
--- a/clockwork_web/static/css/style.css
+++ b/clockwork_web/static/css/style.css
@@ -4451,7 +4451,7 @@ textarea.form-control-lg, .input-group-lg > textarea.form-control,
 
 .pagination a, .pagination span {
   position: relative;
-  display: block;
+  display: inline-block;
   padding: var(--bs-pagination-padding-y) var(--bs-pagination-padding-x);
   font-size: var(--bs-pagination-font-size);
   color: var(--bs-pagination-color);
@@ -4494,11 +4494,11 @@ textarea.form-control-lg, .input-group-lg > textarea.form-control,
 .pagination li:not(:first-child) a, .pagination li span {
   margin-left: -1px;
 }
-.pagination li:first-child a, .pagination li:first-child span {
+.pagination li:first-child a:first-child, .pagination li:first-child span:first-child {
   border-top-left-radius: var(--bs-pagination-border-radius);
   border-bottom-left-radius: var(--bs-pagination-border-radius);
 }
-.pagination li:last-child a, .pagination li:last-child span {
+.pagination li:last-child a:last-child, .pagination li:last-child span:last-child {
   border-top-right-radius: var(--bs-pagination-border-radius);
   border-bottom-right-radius: var(--bs-pagination-border-radius);
 }

--- a/clockwork_web/templates/jobs_search.html
+++ b/clockwork_web/templates/jobs_search.html
@@ -277,8 +277,12 @@
                     <nav class="table_nav" aria-label="table_nav">
                         <ul class="pagination">
                             {% if page_num == 1 %}
-                                <li class="page-item first"><span><i class="fa-solid fa-caret-left"></i></span></li>
+                                <li class="page-item first">
+                                    <span><i class="fa-solid fa-caret-left"></i><i class="fa-solid fa-caret-left"></i></span>
+                                    <span><i class="fa-solid fa-caret-left"></i></span>
+                                </li>
                             {% else %}
+                                <li class="page-item first"><a class="page-link" href="{{ modify_query(page_num=1) }}"><i class="fa-solid fa-caret-left"></i><i class="fa-solid fa-caret-left"></i></a></li>
                                 <li class="page-item first"><a class="page-link" href="{{ modify_query(page_num=page_num - 1) }}"><i class="fa-solid fa-caret-left"></i></a></li>
                             {% endif %}
 
@@ -307,9 +311,13 @@
                                 <li><span class="ellipses">...</span></li>
                             {% endif %}
                             {% if page_num == total_pages %}
-                                <li class="page-item last"><span><i class="fa-solid fa-caret-right"></i></span></li>
+                                <li class="page-item last">
+                                    <span><i class="fa-solid fa-caret-right"></i></span>
+                                    <span><i class="fa-solid fa-caret-right"></i><i class="fa-solid fa-caret-right"></i></span>
+                                </li>
                             {% else %}
                                 <li class="page-item last"><a class="page-link" href="{{ modify_query(page_num=page_num + 1) }}"><i class="fa-solid fa-caret-right"></i></a></li>
+                                <li class="page-item last"><a class="page-link" href="{{ modify_query(page_num=total_pages) }}"><i class="fa-solid fa-caret-right"></i><i class="fa-solid fa-caret-right"></i></a></li>
                             {% endif %}
                         </ul>
                     </nav>


### PR DESCRIPTION
Hi @soline-b ! This is a PR for ticket CW-274. It adds button "last page" and also button "first page" to pagination in job search page. See screenshots below. What do you think?

![Capture d’écran de 2023-05-29 00-15-17](https://github.com/mila-iqia/clockwork/assets/3467054/5442d160-1019-4298-bd71-d7ac675e27df)

![Capture d’écran de 2023-05-29 00-15-22](https://github.com/mila-iqia/clockwork/assets/3467054/22864861-d3b4-43b0-a633-ce180f9faa81)

![Capture d’écran de 2023-05-29 00-15-34](https://github.com/mila-iqia/clockwork/assets/3467054/42665df4-0f12-4a97-9a94-69796233b99d)

![Capture d’écran de 2023-05-29 00-15-36](https://github.com/mila-iqia/clockwork/assets/3467054/7930bf3a-a189-45d9-9229-766616550c49)

![Capture d’écran de 2023-05-29 00-15-45](https://github.com/mila-iqia/clockwork/assets/3467054/222526c3-8edd-48bd-a0c6-9bc55ec1e0fb)

![Capture d’écran de 2023-05-29 00-15-47](https://github.com/mila-iqia/clockwork/assets/3467054/b0858a15-2bb0-4be0-ac0b-b671db427ca6)
