### PR TITLE
CW-342 - Allow to select jobs by job array on job search page.

### DIFF
--- a/clockwork_web/browser_routes/jobs.py
+++ b/clockwork_web/browser_routes/jobs.py
@@ -100,6 +100,7 @@ def route_search():
       "submit_time", "start_time", "end_time"
     - "sort_asc" is an optional integer and used to specify if sorting is
       ascending (1) or descending (-1). Default is 1.
+    - "job_array" is optional and used to specify the job array in which we are looking for jobs
 
     .. :quickref: list all Slurm job as formatted html
     """
@@ -162,6 +163,7 @@ def route_search():
                 "want_count": query.want_count,
                 "sort_by": query.sort_by,
                 "sort_asc": query.sort_asc,
+                "job_array": query.job_array,
             },
         )
 

--- a/clockwork_web/core/jobs_helper.py
+++ b/clockwork_web/core/jobs_helper.py
@@ -222,6 +222,7 @@ def get_jobs(
     want_count=False,
     sort_by="submit_time",
     sort_asc=-1,
+    job_array=None,
 ):
     """
     Set up the filters according to the parameters and retrieve the requested jobs from the database.
@@ -238,6 +239,7 @@ def get_jobs(
                                 defined.
         sort_asc                Whether or not to sort in ascending order (1)
                                 or descending order (-1).
+        job_array               ID of job array in which we look for jobs.
 
     Returns:
         A tuple containing:
@@ -245,6 +247,11 @@ def get_jobs(
             - the total number of jobs corresponding of the filters in the databse, if want_count has been set to
             True, None otherwise, as second element
     """
+
+    # TODO Currently, job_array is just a job ID. To be updated when real job arrays will be available.
+    if job_array is not None and str(job_array) not in job_ids:
+        job_ids.append(str(job_array))
+
     # Set up and combine filters
     filter = get_global_filter(
         username=username,
@@ -388,6 +395,7 @@ def get_jobs_properties_list_per_page():
             "clusters",
             "user",
             "job_id",
+            "job_array",
             "job_name",
             "job_state",
             "start_time",

--- a/clockwork_web/core/search_helper.py
+++ b/clockwork_web/core/search_helper.py
@@ -20,6 +20,8 @@ def parse_search_request(user, args, force_pagination=True):
     want_count = args.get("want_count", type=str, default="False")
     want_count = to_boolean(want_count)
 
+    job_array = args.get("job_array", type=int, default=None)
+
     default_page_number = "1" if force_pagination else None
 
     # Parse the list of clusters
@@ -68,6 +70,7 @@ def parse_search_request(user, args, force_pagination=True):
         sort_by=sort_by,
         sort_asc=sort_asc,
         want_count=want_count,
+        job_array=job_array,
     )
 
     #########################
@@ -111,5 +114,6 @@ def search_request(user, args, force_pagination=True):
         or query.want_count,  # The count is needed if there is pagination or if it is requested
         sort_by=query.sort_by,
         sort_asc=query.sort_asc,
+        job_array=query.job_array,
     )
     return (query, jobs, nbr_total_jobs)

--- a/clockwork_web/static/css/style.css
+++ b/clockwork_web/static/css/style.css
@@ -11329,6 +11329,14 @@ i.fa-arrows-rotate .rotate-360 {
   width: 100%;
   margin: 30px 0;
 }
+.deactivate-search {
+    padding-top: 30px;
+}
+.deactivate-search > a {
+    color: inherit;
+    background-color: rgb(240, 240, 240);
+    border-radius: 1rem;
+}
 
 .btn-red, .btn-red:visited {
   border: 0;

--- a/clockwork_web/static/js/scripts.js
+++ b/clockwork_web/static/js/scripts.js
@@ -59,6 +59,10 @@ jQuery(document).ready(function($){
             }
             params['sort_by'] = $(this).find("input[name='sort_by']").val();
             params['sort_asc'] = parseInt($(this).find("input[name='sort_asc']").val());
+            // Add job_array to URL only if present in form.
+            $(this).find("input[name='job_array']").each(function() {
+                params['job_array'] = parseInt($(this).val());
+            });
 
             var formData = $.param( params );
             var formData = decodeURIComponent(formData);

--- a/clockwork_web/templates/base.html
+++ b/clockwork_web/templates/base.html
@@ -307,10 +307,22 @@
 
                                 <input type="hidden" name="sort_by" value="{{ previous_request_args['sort_by'] }}"/>
                                 <input type="hidden" name="sort_asc" value="{{ previous_request_args['sort_asc'] }}"/>
+                                {% if previous_request_args['job_array'] is not none %}
+                                <input type="hidden" name="job_array" value="{{ previous_request_args['job_array'] }}"/>
+                                {% endif %}
 
-				                 <div class="row">
+				                 <div class="row align-items-center">
+									 <!-- Deselection buttons for search options that are not in search form  -->
+									 <div class="col-sm-12 col-md-8 pb-3 deactivate-search">
+										 {% if previous_request_args['job_array'] is not none %}
+										 <a href="{{ modify_query(job_array=none) }}" title="Reset filter by job array" class="px-3 py-2">
+											 Job array {{ previous_request_args['job_array'] }}&nbsp;&nbsp;&nbsp;&nbsp;
+											 <i class="fa-solid fa-circle-xmark" style="color: #888a85;"></i>
+										 </a>
+										 {% endif %}
+									 </div>
 				                    <!-- button -->
-				                    <div class="col-sm-12 col-md-4 offset-md-8">
+				                    <div class="col-sm-12 col-md-4">
 				                        <button type="submit" class="btn btn-red mb-3">Run search</button>
 				                    </div>
 				                </div>

--- a/clockwork_web/templates/jobs_search.html
+++ b/clockwork_web/templates/jobs_search.html
@@ -97,6 +97,10 @@
                                     <a href="{{ modify_query_sorting(sort_by) }}">Job ID{{ get_sorting_icon(sort_by) }}</a>
                                 </th>
                             {% endif %}
+                            <!-- Job array header -->
+                            {% if (web_settings | check_web_settings_column_display(page_name, "job_array")) %}
+                                <th>Job array</th>
+                            {% endif %}
                             <!-- Job name header -->
                             {% if (web_settings | check_web_settings_column_display(page_name, "job_name")) %}
                                 {% set sort_by = "name" %}
@@ -174,6 +178,16 @@
                             {% if (web_settings | check_web_settings_column_display(page_name, "job_id")) %}
                                 <td>
                                     <a href="/jobs/one?cluster_name={{D_job['slurm']['cluster_name']}}&job_id={{D_job['slurm']['job_id']}}">{{D_job['slurm']['job_id']}}</a>
+                                </td>
+                            {% endif %}
+
+                            <!-- Job array -->
+                            <!-- TODO For now, job array is just job ID. To update when real job arrays will be available -->
+                            {% if (web_settings | check_web_settings_column_display(page_name, "job_array")) %}
+                                <td>
+                                    <a href="{{ modify_query(job_array=D_job['slurm']['job_id']) }}" title="Filter by job array {{D_job['slurm']['job_id']}}">
+                                        <i class="fa-solid fa-table-list"></i>
+                                    </a>
                                 </td>
                             {% endif %}
 

--- a/clockwork_web/templates/settings.html
+++ b/clockwork_web/templates/settings.html
@@ -244,6 +244,7 @@
 		                            <th>Cluster</th>
 		                            <th>User (@mila.quebec)</th>
 		                            <th>Job ID</th>
+		                            <th>Job array</th>
 		                            <th>Job name [:20]</th>
 		                            <th>Job state</th>
 		                            <th>Submit time</th>
@@ -256,7 +257,7 @@
 		                    <tbody>
 		                    	<tr>
 		                    		{% set page_name = "jobs_list" %}
-									{% for column_name in ["clusters", "user","job_id", "job_name", "job_state", "submit_time", "start_time", "end_time", "links"] %}
+									{% for column_name in ["clusters", "user","job_id", "job_array", "job_name", "job_state", "submit_time", "start_time", "end_time", "links"] %}
 		                    		<td><div class="form-check form-switch">
 										{% if (web_settings | check_web_settings_column_display(page_name, column_name)) %}
 											<input name="{{page_name}}_{{column_name}}_toggle" id="{{page_name}}_{{column_name}}_toggle" type="checkbox" class="form-check-input" onclick="switch_column_setting('{{page_name}}', '{{column_name}}')" checked />


### PR DESCRIPTION
Hello @soline-b @gyom ! This is a pull request for CW-342: search jobs by job array.

- For now, job array is a placeholder which is just job ID of related job.
- Job array column can be activated/deactivated for job search page in settings.
- When clicking on job array:
  - Page is reloaded with job array added to search URL.
  - Job array is also added to search form, so that search button will take it into account with other form parameters.
  - A "X" button is added below search form to allow to deselect job array.

Cf screenshots below. What do you think?

NB: In discussions, we also talked about adding "X" button to deselect other hidden filters like "job_ids", but I think it could be done in a future separated PR, once this one is validated.

### Job array column in settings.

![Capture d’écran de 2023-06-15 10-44-01](https://github.com/mila-iqia/clockwork/assets/3467054/4ae8349d-1f42-4393-b08d-86e4c59bed30)

### Job array column in search page, represented with an icon and a tooltip.

![Capture d’écran de 2023-06-15 10-44-09](https://github.com/mila-iqia/clockwork/assets/3467054/8ac076c9-5d12-48ea-ab6a-5bac3d38a168)

### Search page with a selected job array.

![Capture d’écran de 2023-06-15 10-45-03](https://github.com/mila-iqia/clockwork/assets/3467054/c39d2257-d009-45fe-b982-a966e8812208)
