### PR TITLE
Fix wrong cluster nodes list

### DIFF
--- a/clockwork_web/browser_routes/nodes.py
+++ b/clockwork_web/browser_routes/nodes.py
@@ -247,6 +247,6 @@ def set_up_cluster_names_and_node_name_filters(cluster_names=[], node_name=None)
         # for the user
         cluster_names = user_clusters
 
-    f1 = {"slurm.cluster_name": {"$in": user_clusters}}
+    f1 = {"slurm.cluster_name": {"$in": cluster_names}}
 
     return [f0, f1]

--- a/clockwork_web_test/test_browser_nodes.py
+++ b/clockwork_web_test/test_browser_nodes.py
@@ -412,24 +412,30 @@ def test_nodes_with_filter(
         f"/nodes/list?cluster_name={cluster_name}&nbr_items_per_page=1000000"
     )
 
-    expected_nodes = _get_associated_nodes_from_fake_data_in_order(
-        current_user_id, fake_data
-    )
+    # Retrieve all the nodes from the fake data
+    all_nodes = fake_data["nodes"]
 
-    for D_node in expected_nodes:
-        if D_node["slurm"]["cluster_name"] == cluster_name and D_node["slurm"][
-            "cluster_name"
-        ] in get_available_clusters_from_db(current_user_id):
+    if cluster_name not in get_available_clusters_from_db(current_user_id):
+        # If the cluster name is not in the clusters available for the user,
+        # all the available nodes from all the clusters are returned
+        expected_nodes = _get_associated_nodes_from_fake_data_in_order(  # These are all the nodes available for the user
+            current_user_id, fake_data
+        )
+    else:
+        # If the cluster name is in the clusters available for the user,
+        # only the nodes related to this cluster should be displayed
+        expected_nodes = [
+            D_node
+            for D_node in all_nodes
+            if D_node["slurm"]["cluster_name"] == cluster_name
+        ]
+
+    for D_node in all_nodes:
+        if D_node in expected_nodes:
             assert D_node["slurm"]["name"] in response.get_data(as_text=True)
         else:
-            # We're being a little demanding here by asking that the name of the
-            # host should never occur in the document. The host names are unique,
-            # but there's no reason or guarantee that a string like "cn-a003" should NEVER
-            # show up elsewhere in the page for some other reason.
-            # This causes issues when the fake data had node names that were all "machine"
-            # with some integer.
             assert (
-                f"/nodes/one?node_name={D_node['slurm']['name']}&cluster_name={cluster_name}"
+                f"&cluster_name={D_node['slurm']['cluster_name']}"
                 not in response.get_data(as_text=True)
             )
 


### PR DESCRIPTION
When displaying the nodes list of a cluster (request `/nodes/list?cluster_name=beluga`), the nodes of all clusters are displayed