### PR TITLE
Allow sacct and sinfo parsers to create missing directories when writing the output file of the jobs and nodes imports

### DIFF
--- a/slurm_state/sacct_parser.py
+++ b/slurm_state/sacct_parser.py
@@ -434,6 +434,9 @@ def generate_job_report(
                 )
             """
 
+            # Create directories if needed
+            os.makedirs(os.path.dirname(file_name), exist_ok=True)
+
             # Write the command output to a file
             with open(file_name, "w") as outfile:
                 for line in ssh_stdout.readlines():

--- a/slurm_state/sinfo_parser.py
+++ b/slurm_state/sinfo_parser.py
@@ -233,6 +233,9 @@ def generate_node_report(
             )
         """
 
+        # Create directories if needed
+        os.makedirs(os.path.dirname(file_name), exist_ok=True)
+
         # Write the command output to a file
         with open(file_name, "w") as outfile:
             for line in ssh_stdout.readlines():


### PR DESCRIPTION
This is done in response of the issue CW-398