### PR TITLE
Redirect when not connected

### DIFF
--- a/clockwork_web/browser_routes/settings.py
+++ b/clockwork_web/browser_routes/settings.py
@@ -120,24 +120,13 @@ def route_set_nbr_items_per_page():
         # Check if nbr_items_per_page is a positive integer
         if type(nbr_items_per_page) == int and nbr_items_per_page > 0:
 
-            if current_user.is_authenticated():
-                # If it is, update this number in the current user's settings and
-                # retrieve the status code and status message associated to this
-                # operation
-                (
-                    status_code,
-                    status_message,
-                ) = current_user.settings_nbr_items_per_page_set(nbr_items_per_page)
-            else:
-                # Otherwise, return an error
-                return (
-                    render_template_with_user_settings(
-                        "error.html",
-                        error_msg=gettext("The user is not authenticated."),
-                        previous_request_args=previous_request_args,
-                    ),
-                    403,  # Forbidden
-                )
+            # If it is, update this number in the current user's settings and
+            # retrieve the status code and status message associated to this
+            # operation
+            (
+                status_code,
+                status_message,
+            ) = current_user.settings_nbr_items_per_page_set(nbr_items_per_page)
 
             if status_code == 200:
                 # If a success has been return, redirect to the settings page
@@ -195,18 +184,7 @@ def route_set_dark_mode():
 
     # Set the dark mode value to True in the current user's web settings and
     # retrieve the status code and status message associated to the operation
-    if current_user.is_authenticated():
-        (status_code, status_message) = current_user.settings_dark_mode_enable()
-    else:
-        # Otherwise, return an error
-        return (
-            render_template_with_user_settings(
-                "error.html",
-                error_msg=gettext("The user is not authenticated."),
-                previous_request_args=previous_request_args,
-            ),
-            403,  # Forbidden
-        )
+    (status_code, status_message) = current_user.settings_dark_mode_enable()
 
     if status_code == 200:
         # If a success has been returned
@@ -237,20 +215,10 @@ def route_unset_dark_mode():
 
     # Initialize the request arguments (it is further transferred to the HTML)
     previous_request_args = {}
-    if current_user.is_authenticated():
-        # Set the dark mode value to False in the current user's web settings and
-        # retrieve the status code and status message associated to the operation
-        (status_code, status_message) = current_user.settings_dark_mode_disable()
-    else:
-        # Otherwise, return an error
-        return (
-            render_template_with_user_settings(
-                "error.html",
-                error_msg=gettext("The user is not authenticated."),
-                previous_request_args=previous_request_args,
-            ),
-            403,  # Forbidden
-        )
+
+    # Set the dark mode value to False in the current user's web settings and
+    # retrieve the status code and status message associated to the operation
+    (status_code, status_message) = current_user.settings_dark_mode_disable()
 
     if status_code == 200:
         # If a success has been returned
@@ -496,25 +464,13 @@ def route_set_date_format():
     if date_format:
         # Check if the date format is supported
         if date_format in get_available_date_formats():
-            if current_user.is_authenticated():
-                # If the requested date format is expected, update the preferred
-                # date format of the current user and retrieve the status code
-                # and status message associated to this operation
-                (
-                    status_code,
-                    status_message,
-                ) = current_user.settings_date_format_set(date_format)
-
-            else:
-                # Otherwise, return an error
-                return (
-                    render_template_with_user_settings(
-                        "error.html",
-                        error_msg=gettext("The user is not authenticated."),
-                        previous_request_args=previous_request_args,
-                    ),
-                    403,  # Forbidden
-                )
+            # If the requested date format is expected, update the preferred
+            # date format of the current user and retrieve the status code
+            # and status message associated to this operation
+            (
+                status_code,
+                status_message,
+            ) = current_user.settings_date_format_set(date_format)
 
             if status_code == 200:
                 # If a success has been return, redirect to the home page
@@ -578,24 +534,14 @@ def route_set_time_format():
     if time_format:
         # Check if the date format is supported
         if time_format in get_available_time_formats():
-            if current_user.is_authenticated():
-                # If the requested time format is expected, update the preferred
-                # time format of the current user and retrieve the status code
-                # and status message associated to this operation
-                (
-                    status_code,
-                    status_message,
-                ) = current_user.settings_time_format_set(time_format)
-            else:
-                # Otherwise, return an error
-                return (
-                    render_template_with_user_settings(
-                        "error.html",
-                        error_msg=gettext("The user is not authenticated."),
-                        previous_request_args=previous_request_args,
-                    ),
-                    403,  # Forbidden
-                )
+
+            # If the requested time format is expected, update the preferred
+            # time format of the current user and retrieve the status code
+            # and status message associated to this operation
+            (
+                status_code,
+                status_message,
+            ) = current_user.settings_time_format_set(time_format)
 
             if status_code == 200:
                 # If a success has been return, redirect to the home page

--- a/clockwork_web/login_routes.py
+++ b/clockwork_web/login_routes.py
@@ -206,9 +206,9 @@ def route_callback():
     from flask import current_app
 
     current_app.logger.debug(
-        "called login_user(user) for user with email %s, user.is_authenticated() is %s",
+        "called login_user(user) for user with email %s, user.is_authenticated is %s",
         user.mila_email_username,
-        user.is_authenticated(),
+        user.is_authenticated,
     )
     # Send user back to homepage
     return redirect(url_for("index"))

--- a/clockwork_web/server_app.py
+++ b/clockwork_web/server_app.py
@@ -151,7 +151,7 @@ def create_app(extra_config: dict):
     @babel.localeselector
     def get_locale():
         # If the user is authenticated
-        if current_user and current_user.is_authenticated():
+        if current_user and current_user.is_authenticated:
 
             return current_user.get_language()
 
@@ -251,7 +251,7 @@ def create_app(extra_config: dict):
         where people can click on the "login" button on the web interface.
         """
 
-        if current_user.is_authenticated():
+        if current_user.is_authenticated:
             app.logger.debug("in route for '/'; redirecting to jobs/")
             return redirect("jobs/")
         else:

--- a/clockwork_web/templates/base.html
+++ b/clockwork_web/templates/base.html
@@ -70,7 +70,7 @@
 						{% endif %}
 					</a>
 				</div>
-				{% if current_user.is_authenticated() %}
+				{% if current_user.is_authenticated %}
 				<div class="col">
 					<nav class="navbar-expand-lg">
 						<div class="container-fluid">
@@ -126,7 +126,7 @@
 		</div>
 
 		{% block form %}
-		{% if request.path != '/jobs/dashboard' and current_user.is_authenticated() %}
+		{% if request.path != '/jobs/dashboard' and current_user.is_authenticated %}
 			<!-- Search jobs form -->
 			<div id="formBlock">
 				<div class="search_button formCollapse {{ 'collapse' if request.path != '/jobs/search' }} {{ 'show' if request.path == '/jobs/search' }}" id="mainCollapse">

--- a/clockwork_web/user.py
+++ b/clockwork_web/user.py
@@ -94,15 +94,6 @@ class User(UserMixin):
             "actions"
         ] = False
 
-    # If we don't set those two values ourselves, we are going
-    # to have users being asked to login every time they click
-    # on a link or refresh the pages.
-    def is_authenticated(self):
-        return True
-
-    def is_active(self):
-        return self.status == "enabled"
-
     def get_id(self):
         return self.mila_email_username
 
@@ -350,6 +341,3 @@ class AnonUser(AnonymousUserMixin):
             A dictionary presenting the default web settings.
         """
         return self.web_settings
-
-    def is_authenticated(self):
-        return False

--- a/clockwork_web_test/test_browser_settings.py
+++ b/clockwork_web_test/test_browser_settings.py
@@ -98,7 +98,6 @@ def test_settings_set_nbr_items_per_page_zero_or_negative_value(
     assert response.status_code == 400  # Bad Request
 
 
-
 def test_settings_set_date_format_missing_argument(client, fake_data):
     """
     Test the function route_set_date_format without sending a
@@ -176,7 +175,9 @@ def test_settings_set_date_format_success(client, fake_data, date_format):
     assert response.status_code == 302  # Redirect
 
     # Retrieve the user data
-    D_user = get_db()["users"].find_one({"mila_email_username": user['mila_email_username']})
+    D_user = get_db()["users"].find_one(
+        {"mila_email_username": user["mila_email_username"]}
+    )
     # Assert the date format setting has been modified
     assert D_user["web_settings"]["date_format"] == date_format
 
@@ -407,7 +408,9 @@ def test_settings_set_and_unset_column_display_good_request(
         assert response.status_code == 200  # Success
 
         # Retrieve the user data
-        D_user = get_db()["users"].find_one({"mila_email_username": user["mila_email_username"]})
+        D_user = get_db()["users"].find_one(
+            {"mila_email_username": user["mila_email_username"]}
+        )
         # Assert the column display value has been modified
         assert D_user["web_settings"]["column_display"][page_name][column_name] == (
             not previous_value
@@ -424,7 +427,9 @@ def test_settings_set_and_unset_column_display_good_request(
     "nbr_items_per_page",
     [13, 2],
 )
-def test_settings_set_nbr_items_per_page_unknown_user(client_with_login, nbr_items_per_page):
+def test_settings_set_nbr_items_per_page_unknown_user(
+    client_with_login, nbr_items_per_page
+):
     """
     Test the function route_set_nbr_items_per_page when sending a zero or
     negative integer as nbr_items_per_page.
@@ -460,7 +465,7 @@ def test_settings_enable_dark_mode_with_no_user(client_with_login):
     response = client_with_login.get(f"/settings/web/dark_mode/set")
 
     # Check the status code
-    assert response.status_code == 302 # Redirect
+    assert response.status_code == 302  # Redirect
 
 
 def test_settings_disable_dark_mode_with_no_user(client_with_login):
@@ -477,7 +482,7 @@ def test_settings_disable_dark_mode_with_no_user(client_with_login):
     response = client_with_login.get(f"/settings/web/dark_mode/unset")
 
     # Check the status code
-    assert response.status_code == 302 # Redirect
+    assert response.status_code == 302  # Redirect
 
 
 def test_settings_set_date_format_with_no_user(client_with_login):
@@ -497,7 +502,7 @@ def test_settings_set_date_format_with_no_user(client_with_login):
     )
 
     # Check the status code
-    assert response.status_code == 302 # Redirect
+    assert response.status_code == 302  # Redirect
 
 
 def test_settings_set_time_format_with_no_user(client_with_login):

--- a/test_config.toml
+++ b/test_config.toml
@@ -1,6 +1,8 @@
 [flask]
 testing=true
-login_disabled=true
+# login_disabled is set to false in order to test the "true" handling of the anonymous user
+# but it could be changed for testing purposes
+login_disabled=false
 secret_key="testing_secret_key"
 
 [sentry]


### PR DESCRIPTION
_This Pull Request relates to ticket CW-402._

When trying to access to some pages (for instance `/jobs/search`) unlogged, a anonymous user was not redirected to the login page, but the page was displayed anyway. As the anonymous user has no access, this did not end up with a leak of data, but could lead to some errors (for instance when trying to change web settings of the user) and is counter-intuitive for the user experience.