### PR TITLE
Fix Slurm version retrieving through sacct

### DIFF
--- a/slurm_state/parsers/slurm_parser.py
+++ b/slurm_state/parsers/slurm_parser.py
@@ -49,17 +49,16 @@ class SlurmParser:
             # return the value of the configuration
             return self.cluster["slurm_version"]
         else:
-            print("3")
             # Launch the sacct or sinfo command to get its version
             remote_command = f"{self.slurm_command_path} -V"
             response = self.launch_slurm_command(remote_command)
             assert len(response) == 1
             version_regex = re.compile(r"^slurm (\d+\.\d+\.\d+)$")
-            if m := version_regex.match(response):
+            if m := version_regex.match(response[0]):
                 return m.group(1)
             # If the version has not been identified, raise an error
             raise Exception(
-                f'The version "{response}" has not been recognized as a Slurm version.'
+                f'The version "{response[0]}" has not been recognized as a Slurm version.'
             )
 
     def launch_slurm_command(self, remote_command):


### PR DESCRIPTION
Fix the following error:
```
Nov 20 10:56:00 clockwork-scrape systemd[1]: Starting clockwork slurm scraper...
Nov 20 10:56:01 clockwork-scrape python3[1180653]: 3
Nov 20 10:56:01 clockwork-scrape python3[1180653]: The command launched through SSH is:
Nov 20 10:56:01 clockwork-scrape python3[1180653]: /opt/slurm/bin/sacct -V
Nov 20 10:56:01 clockwork-scrape python3[1180653]: Successful SSH connection to mila-automation@clockwork-stats port 22.
Nov 20 10:56:01 clockwork-scrape python3[1180653]: Traceback (most recent call last):
Nov 20 10:56:01 clockwork-scrape python3[1180653]:   File "/opt/clockwork/slurm_state/read_report_commit_to_db.py", line 136, in <module>
Nov 20 10:56:01 clockwork-scrape python3[1180653]:     main(sys.argv)
Nov 20 10:56:01 clockwork-scrape python3[1180653]:   File "/opt/clockwork/slurm_state/read_report_commit_to_db.py", line 99, in main
Nov 20 10:56:01 clockwork-scrape python3[1180653]:     main_read_report_and_update_collection(
Nov 20 10:56:01 clockwork-scrape python3[1180653]:   File "/opt/clockwork/slurm_state/mongo_update.py", line 153, in main_read_report_and_update_collection
Nov 20 10:56:01 clockwork-scrape python3[1180653]:     parser = JobParser(
Nov 20 10:56:01 clockwork-scrape python3[1180653]:   File "/opt/clockwork/slurm_state/parsers/job_parser.py", line 26, in __init__
Nov 20 10:56:01 clockwork-scrape python3[1180653]:     super().__init__("jobs", "sacct", cluster_name, slurm_version=slurm_version)
Nov 20 10:56:01 clockwork-scrape python3[1180653]:   File "/opt/clockwork/slurm_state/parsers/slurm_parser.py", line 38, in __init__
Nov 20 10:56:01 clockwork-scrape python3[1180653]:     self.slurm_version = self.get_slurm_version()
Nov 20 10:56:01 clockwork-scrape python3[1180653]:   File "/opt/clockwork/slurm_state/parsers/slurm_parser.py", line 58, in get_slurm_version
Nov 20 10:56:01 clockwork-scrape python3[1180653]:     if m := version_regex.match(response):
Nov 20 10:56:01 clockwork-scrape python3[1180653]: TypeError: expected string or bytes-like object
Nov 20 10:56:01 clockwork-scrape systemd[1]: clockwork-scrape-mila.service: Main process exited, code=exited, status=1/FAILURE
Nov 20 10:56:01 clockwork-scrape systemd[1]: clockwork-scrape-mila.service: Failed with result 'exit-code'.
Nov 20 10:56:01 clockwork-scrape systemd[1]: Failed to start clockwork slurm scraper.
```
