### PR TITLE
CW-511: Ajouter un affichage spécifique pour les dict user-job présentant des noms spécifiques

### DIFF
--- a/clockwork_frontend_test/test_jobs_search.py
+++ b/clockwork_frontend_test/test_jobs_search.py
@@ -668,7 +668,7 @@ def test_filter_by_job_user_props(page: Page):
 
 @pytest.mark.parametrize(
     "prop_name,title",
-    (("comet_hyperlink", "Comet link"), ("wandb_hyperlink", "W&B link")),
+    (("comet_hyperlink", "Comet link"), ("wandb_hyperlink", "WANDB link")),
 )
 def test_special_user_props(page: Page, prop_name: str, title: str):
     current_user = "student01@mila.quebec"

--- a/clockwork_web/static/css/style.css
+++ b/clockwork_web/static/css/style.css
@@ -11857,4 +11857,5 @@ table.table-striped td.links a.hyperlink-user-prop {
     color: white;
     font-weight: bold;
     padding: 2px 5px 2px 5px;
+    border-radius: 6px;
 }

--- a/clockwork_web/static/css/style.css
+++ b/clockwork_web/static/css/style.css
@@ -11850,3 +11850,11 @@ ul.pagination li:first-child span, ul.pagination li:last-child span {
 }
 
 /*# sourceMappingURL=style.css.map */
+
+table.table-striped td.links a.hyperlink-user-prop {
+    display: inline-block;
+    background-color: rgb(84, 171, 180);
+    color: white;
+    font-weight: bold;
+    padding: 2px 5px 2px 5px;
+}

--- a/clockwork_web/templates/jobs_search.html
+++ b/clockwork_web/templates/jobs_search.html
@@ -201,12 +201,14 @@
                             {% if (web_settings | check_web_settings_column_display(page_name, "job_user_props")) %}
                                 <td>
                                     {% for D_user_prop_name, D_user_prop_content in D_job.get('job_user_props', {}).items() %}
+                                    {% if D_user_prop_name not in ("comet_hyperlink", "wandb_hyperlink") %}
                                     <p>
                                     <a href="{{ modify_query(user_prop_name=D_user_prop_name, user_prop_content=D_user_prop_content, page_num=1) }}" title="Filter by job-user prop &quot;{{D_user_prop_name}}&quot;: &quot;{{D_user_prop_content}}&quot;">
                                         <strong>{{ D_user_prop_name }}</strong><br/>
                                         {{ D_user_prop_content }}
                                     </a>
                                     </p>
+                                    {% endif %}
                                     {% endfor %}
                                 </td>
                             {% endif %}
@@ -274,6 +276,27 @@
                                         {# Other link (here, it is a placeholder with no condition) #}
                                         <!-- this is a placeholder -->
                                         <a href='' data-bs-toggle='tooltip' data-bs-placement='right' title='Link to another place'><i class='fa-solid fa-link-horizontal'></i></a>
+                                    {% endif %}
+                                    {# Links from user props are set by current user, so they should be visible if available #}
+                                    {% if "comet_hyperlink" in D_job.get("job_user_props", {}) %}
+                                    <a href='{{ D_job["job_user_props"]["comet_hyperlink"] }}'
+                                       target="_blank"
+                                       class='hyperlink-user-prop comet_hyperlink'
+                                       data-bs-toggle='tooltip'
+                                       data-bs-placement='right'
+                                       title='Comet link'>
+                                        COMET
+                                    </a>
+                                    {% endif %}
+                                    {% if "wandb_hyperlink" in D_job.get("job_user_props", {}) %}
+                                    <a href='{{ D_job["job_user_props"]["wandb_hyperlink"] }}'
+                                       target="_blank"
+                                       class='hyperlink-user-prop wandb_hyperlink'
+                                       data-bs-toggle='tooltip'
+                                       data-bs-placement='right'
+                                       title='W&B link'>
+                                        W&B
+                                    </a>
                                     {% endif %}
                                 </td>
                             {% endif %}

--- a/clockwork_web/templates/jobs_search.html
+++ b/clockwork_web/templates/jobs_search.html
@@ -294,8 +294,8 @@
                                        class='hyperlink-user-prop wandb_hyperlink'
                                        data-bs-toggle='tooltip'
                                        data-bs-placement='right'
-                                       title='W&B link'>
-                                        W&B
+                                       title='WANDB link'>
+                                        WANDB
                                     </a>
                                     {% endif %}
                                 </td>

--- a/scripts/insert_hardcoded_values.py
+++ b/scripts/insert_hardcoded_values.py
@@ -64,7 +64,10 @@ def get_job_user_props_hardcoded_values(fake_data: dict):
         {"name": "je suis une user prop 2"},
         {"name": "je suis une user prop 3"},
         {"name": "je suis une user prop 3", "name2": "je suis une user prop 4"},
-        {"name": "je suis une user prop 1"},
+        {
+            "comet_hyperlink": "https://comet.example.com",
+            "wandb_hyperlink": "https://wandb.example.com/?job=thisjob",
+        },
     ]
 
     return [

--- a/test_common/fake_data.json
+++ b/test_common/fake_data.json
@@ -6043,7 +6043,8 @@
       "job_id": "308858",
       "cluster_name": "beluga",
       "props": {
-        "name": "je suis une user prop 1"
+          "comet_hyperlink": "https://comet.example.com",
+          "wandb_hyperlink": "https://wandb.example.com/?job=thisjob"
       }
     }
   ]


### PR DESCRIPTION
Salut @soline-b ! Voici une PR pour CW-511. On peut voir l'allure actuelle des liens commet et wandb dans la capture ci-dessous.

Je suppose qu'on peut faire mieux en terme d'affichage, donc j'attends vos suggestions :) .

Aussi, pour faire les tests, j'ai dû à nouveau modifier le fichier `fake_data.json`. Peut-être qu'il faudra à nouveau les régénérer ! Mais cette fois, normalement, ce ne sera pas nécessaire de mettre à jour les tests.


![Screenshot 2024-06-19 at 16-10-32 Clockwork -](https://github.com/mila-iqia/clockwork/assets/3467054/6058fc9c-1420-4562-adcc-d08dab5ea04d)
