### PR TITLE
[CW-560] Faire en sorte que le script de ménage des jobs accepte une durée (en jours)

### DIFF
--- a/scripts_test/requirements.txt
+++ b/scripts_test/requirements.txt
@@ -7,5 +7,6 @@ packaging==23.2
 pluggy==1.3.0
 pymongo==4.6.3
 pytest==7.4.2
+pytest-freezegun==0.4.2
 toml==0.10.2
 tomli==2.0.1


### PR DESCRIPTION
Hello @soline-b ! Voici une PR de préparation pour CW-560. Elle ajoute un paramètre `--days <n>` pour dire au script: `garde tous les jobs des <n> derniers jours`. On pourra ensuite utiliser ce paramètre pour le rôle ansible.